### PR TITLE
Add CI linting workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: lint
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+    - name: Lint with flake8
+      run: |
+        flake8 . --count --max-line-length=99 --statistics

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: lint
 on:
   push:
     branches: [ $default-branch ]
-  pull_request
+  pull_request:
 
 jobs:
   lint:

--- a/twoaxistracking/__init__.py
+++ b/twoaxistracking/__init__.py
@@ -1,9 +1,9 @@
-from .layout import generate_field_layout
-from .shading import shaded_fraction
+from .layout import generate_field_layout  # noqa: F401
+from .shading import shaded_fraction  # noqa: F401
 
 
 try:
-    from shapely.geos import lgeos
+    from shapely.geos import lgeos  # noqa: F401
 except OSError as err:
     msg = (
         "An error was encountered when importing the shapely package. "

--- a/twoaxistracking/layout.py
+++ b/twoaxistracking/layout.py
@@ -69,7 +69,7 @@ def generate_field_layout(gcr, collector_area, L_min, neighbor_order,
     ----------
     .. [1] `Shading and land use in regularly-spaced sun-tracking collectors, Cumpston & Pye.
        <https://doi.org/10.1016/j.solener.2014.06.012>`_
-    """  # noqa: E501
+    """
     # Consider special layouts which can be defined only by GCR
     if layout_type == 'square':
         aspect_ratio = 1

--- a/twoaxistracking/shading.py
+++ b/twoaxistracking/shading.py
@@ -39,7 +39,7 @@ def shaded_fraction(solar_azimuth, solar_elevation,
     -------
     shaded_fraction: float
         Shaded fraction for the specific solar position and field layout.
-    """  # noqa: E501
+    """
     # If the sun is below the horizon, set the shaded fraction to nan
     if solar_elevation < 0:
         return np.nan
@@ -61,7 +61,7 @@ def shaded_fraction(solar_azimuth, solar_elevation,
         if np.sqrt(x**2+y**2) < L_min:
             # Project the geometry of the shading collector onto the plane
             # of the investigated collector
-            shade_geometry = shapely.affinity.translate(collector_geometry, x, y)  # noqa: E501
+            shade_geometry = shapely.affinity.translate(collector_geometry, x, y)
             # Update the unshaded area based on overlapping shade
             unshaded_geomtry = unshaded_geomtry.difference(shade_geometry)
             if plot:


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to run the `flake8` linter on the entire codebase.  If it eventually becomes desirable to have parts of the repository be non-pep8-compliant, we may want to change this workflow to only check the diff of the PR, but since the codebase is currently completely compliant with pep8 (except for a few minor places also addressed in this PR), I think this is fine for now.